### PR TITLE
fix: remove the staking tx type

### DIFF
--- a/client/schema.go
+++ b/client/schema.go
@@ -127,21 +127,10 @@ func NewWithdrawStakingEvent(stakingTxHashHex string) WithdrawStakingEvent {
 	}
 }
 
-type StakingTxType string
-
-const (
-	ActiveTxType    StakingTxType = "active"
-	UnbondingTxType StakingTxType = "unbonding"
-)
-
-func (s StakingTxType) ToString() string {
-	return string(s)
-}
-
 type ExpiredStakingEvent struct {
-	EventType        EventType     `json:"event_type"` // always 4. ExpiredStakingEventType
-	StakingTxHashHex string        `json:"staking_tx_hash_hex"`
-	TxType           StakingTxType `json:"tx_type"`
+	EventType        EventType `json:"event_type"` // always 4. ExpiredStakingEventType
+	StakingTxHashHex string    `json:"staking_tx_hash_hex"`
+	TxType           string    `json:"tx_type"`
 }
 
 func (e ExpiredStakingEvent) GetEventType() EventType {
@@ -152,7 +141,7 @@ func (e ExpiredStakingEvent) GetStakingTxHashHex() string {
 	return e.StakingTxHashHex
 }
 
-func NewExpiredStakingEvent(stakingTxHashHex string, txType StakingTxType) ExpiredStakingEvent {
+func NewExpiredStakingEvent(stakingTxHashHex string, txType string) ExpiredStakingEvent {
 	return ExpiredStakingEvent{
 		EventType:        ExpiredStakingEventType,
 		StakingTxHashHex: stakingTxHashHex,

--- a/tests/setup.go
+++ b/tests/setup.go
@@ -130,7 +130,7 @@ func buildNExpiryEvents(numOfEvent int) []*client.ExpiredStakingEvent {
 		expiryEv := &client.ExpiredStakingEvent{
 			EventType:        client.ExpiredStakingEventType,
 			StakingTxHashHex: "0x1234567890abcdef" + fmt.Sprint(i),
-			TxType:           client.ActiveTxType,
+			TxType:           "active",
 		}
 		expiryEvents = append(expiryEvents, expiryEv)
 	}


### PR DESCRIPTION
Remove the custom type. The queue should have no business logic around what's "valid" tx. It shall be within the API service.