### PR TITLE
feat: add delay queue and DLX

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,80 @@
 # staking-queue-client
+
+We focus on using rabbitMQ for message processing in Babylon today.
+
+## Overview
+
+Our RabbitMQ client is designed to handle robust message processing with mechanisms 
+for error handling and message retry capabilities. The setup involves the following components:
+
+- **Main Queues**: Primary queues where messages are initially sent and processed.
+- **Delayed Queues**: Queues used to temporarily hold messages that need to be retried after a delay.
+- **Dead Letter Exchange (DLX)**: A special exchange used to reroute messages 
+from main queues to delayed queues when processing fails or when a message needs to be delayed.
+
+## Configuration Details
+
+### Dead Letter Exchange (DLX)
+
+- **Purpose**: The DLX handles messages that fail during processing or messages 
+that need to be retried after a specific delay.
+- **Name**: `common_dlx`
+
+### Main Queues
+
+Main queues are created by initiating the `NewQueueClient`.
+For example, in the Babylon mainnet phase 1, we have following queues:
+
+```go
+const (
+	ActiveStakingQueueName    string = "active_staking_queue"
+	UnbondingStakingQueueName string = "unbonding_staking_queue"
+	WithdrawStakingQueueName  string = "withdraw_staking_queue"
+	ExpiredStakingQueueName   string = "expired_staking_queue"
+)
+```
+
+- **Configuration**:
+  - Each main queue is configured with the DLX (`common_dlx`) as the dead-letter exchange.
+  - Messages that fail to process are sent to the DLX with a specific routing key 
+  that directs them to the corresponding delayed queue. 
+  The routing key is in the form of `{{queueName}}` + `_routing_key`
+
+### Delayed Queues
+
+For each queue that are created, we also auto-provision a corresponding delayed queue
+The name of the delayed queue is in the form of `{{queueName}}` + `_delay`
+
+- **Purpose**: Delayed queues hold messages for a predetermined time before 
+they are sent back to the main queue for reprocessing.
+- **TTL (Time To Live)**: Each delayed queue is configured with a TTL. 
+After the TTL expires, messages are automatically sent back to the main queue.
+- **Routing**: Messages are routed back to the main queue using the default exchange, 
+which routes messages based on the queue name.
+
+## Re-queueing Messages
+
+Re-queueing of messages occurs when our application is temporarily unable to process 
+them for any reason. To manage this effectively, we have implemented a custom 
+solution that delays the re-queueing of messages. 
+This delay ensures that the service can process these messages correctly when it returns to a suitable state.
+
+### Delayed Re-queueing Strategy
+
+RabbitMQ does not natively support delayed message re-queueing, 
+so we have devised a custom approach to handle this requirement:
+
+- **Delayed Queues with TTL**: When the `ReQueueMessage` function is called, 
+the message is sent directly to a specially configured delay queue. 
+This delay queue has a predefined Time To Live (TTL), 
+after which the message is automatically redirected back to the main queue for processing.
+
+- **Message Retry Tracking**: Each time a message is re-queued, 
+we increment its retry attempt count. This is accomplished by cloning the original 
+message into a new message with an incremented retry count. 
+The original message is then deleted from the queue after the new message is successfully enqueued.
+
+This system ensures that messages are not lost and are processed in an orderly 
+manner once the application is ready to handle them again. It provides a robust 
+solution to manage message processing failures and maintain service reliability 
+even under varying system conditions.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ const (
 
 ### Delayed Queues
 
-For each queue that are created, we also auto-provision a corresponding delayed queue
+For each queue that are created, we also auto-provision a corresponding delayed queue.
 The name of the delayed queue is in the form of `{{queueName}}` + `_delay`
 
 - **Purpose**: Delayed queues hold messages for a predetermined time before 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # staking-queue-client
 
-We focus on using rabbitMQ for message processing in Babylon today.
+This document focuses on the usage of RabbitMQ for message processing in the Babylon system.
 
 ## Overview
 
@@ -42,7 +42,8 @@ const (
 
 ### Delayed Queues
 
-For each queue that are created, we also auto-provision a corresponding delayed queue.
+For each queue that is created, we also auto-provision a corresponding delayed queue.  
+
 The name of the delayed queue is in the form of `{{queueName}}` + `_delay`
 
 - **Purpose**: Delayed queues hold messages for a predetermined time before 
@@ -54,7 +55,7 @@ which routes messages based on the queue name.
 
 ## Re-queueing Messages
 
-Re-queueing of messages occurs when our application is temporarily unable to process 
+Re-queueing of messages occurs when the application is temporarily unable to process  
 them for any reason. To manage this effectively, we have implemented a custom 
 solution that delays the re-queueing of messages. 
 This delay ensures that the service can process these messages correctly when it returns to a suitable state.

--- a/client/client.go
+++ b/client/client.go
@@ -1,6 +1,10 @@
 package client
 
-import "context"
+import (
+	"context"
+
+	"github.com/babylonchain/staking-queue-client/config"
+)
 
 type QueueMessage struct {
 	Body          string
@@ -27,6 +31,6 @@ type QueueClient interface {
 	ReQueueMessage(ctx context.Context, message QueueMessage) error
 }
 
-func NewQueueClient(queueURL, user, pass, queueName string) (QueueClient, error) {
-	return NewRabbitMqClient(queueURL, user, pass, queueName)
+func NewQueueClient(config *config.QueueConfig, queueName string) (QueueClient, error) {
+	return NewRabbitMqClient(config, queueName)
 }

--- a/config/queue.go
+++ b/config/queue.go
@@ -15,12 +15,16 @@ const (
 )
 
 type QueueConfig struct {
-	QueueUser              string        `mapstructure:"queue_user"`
-	QueuePassword          string        `mapstructure:"queue_password"`
-	Url                    string        `mapstructure:"url"`
+	QueueUser     string `mapstructure:"queue_user"`
+	QueuePassword string `mapstructure:"queue_password"`
+	Url           string `mapstructure:"url"`
+	// QueueProcessingTimeout is the maximum time a message will be processed in the application
 	QueueProcessingTimeout time.Duration `mapstructure:"processing_timeout"`
-	MsgMaxRetryAttempts    int32         `mapstructure:"msg_max_retry_attempts"`
-	ReQueueDelayTime       time.Duration `mapstructure:"requeue_delay_time"`
+	// MsgMaxRetryAttempts is the maximum number of times a message will be retried
+	MsgMaxRetryAttempts int32 `mapstructure:"msg_max_retry_attempts"`
+	// ReQueueDelayTime is the time a message will be hold in delay queue before
+	// sent to main queue again
+	ReQueueDelayTime time.Duration `mapstructure:"requeue_delay_time"`
 }
 
 func (cfg *QueueConfig) Validate() error {

--- a/config/queue.go
+++ b/config/queue.go
@@ -9,7 +9,7 @@ const (
 	defaultQueueUser                = "user"
 	defaultQueuePassword            = "password"
 	defaultQueueUrl                 = "localhost:5672"
-	defaultQueueProcessingTimeout   = 5 * time.Second
+	defaultQueueProcessingTimeout   = 5
 	defaultQueueMsgMaxRetryAttempts = 10
 	defaultReQueueDelayTime         = 5
 )
@@ -20,7 +20,7 @@ type QueueConfig struct {
 	Url                    string        `mapstructure:"url"`
 	QueueProcessingTimeout time.Duration `mapstructure:"processing_timeout"`
 	MsgMaxRetryAttempts    int32         `mapstructure:"msg_max_retry_attempts"`
-	ReQueueDelayTime       int           `mapstructure:"requeue_delay_time"`
+	ReQueueDelayTime       time.Duration `mapstructure:"requeue_delay_time"`
 }
 
 func (cfg *QueueConfig) Validate() error {

--- a/config/queue.go
+++ b/config/queue.go
@@ -11,6 +11,7 @@ const (
 	defaultQueueUrl                 = "localhost:5672"
 	defaultQueueProcessingTimeout   = 5 * time.Second
 	defaultQueueMsgMaxRetryAttempts = 10
+	defaultReQueueDelayTime         = 5
 )
 
 type QueueConfig struct {
@@ -19,6 +20,7 @@ type QueueConfig struct {
 	Url                    string        `mapstructure:"url"`
 	QueueProcessingTimeout time.Duration `mapstructure:"processing_timeout"`
 	MsgMaxRetryAttempts    int32         `mapstructure:"msg_max_retry_attempts"`
+	ReQueueDelayTime       int           `mapstructure:"requeue_delay_time"`
 }
 
 func (cfg *QueueConfig) Validate() error {
@@ -42,6 +44,11 @@ func (cfg *QueueConfig) Validate() error {
 		return fmt.Errorf("invalid queue message max retry attempts")
 	}
 
+	if cfg.ReQueueDelayTime <= 0 {
+		return fmt.Errorf(`invalid requeue delay time. 
+		It should be greater than 0, the unit is seconds`)
+	}
+
 	return nil
 }
 
@@ -52,5 +59,6 @@ func DefaultQueueConfig() *QueueConfig {
 		Url:                    defaultQueueUrl,
 		QueueProcessingTimeout: defaultQueueProcessingTimeout,
 		MsgMaxRetryAttempts:    defaultQueueMsgMaxRetryAttempts,
+		ReQueueDelayTime:       defaultReQueueDelayTime,
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/babylonchain/staking-queue-client
 
 go 1.21.6
 
-toolchain go1.22.0
-
 require (
 	github.com/rabbitmq/amqp091-go v1.9.0
 	github.com/stretchr/testify v1.9.0

--- a/tests/setup.go
+++ b/tests/setup.go
@@ -37,11 +37,11 @@ func setupTestQueueConsumer(t *testing.T, cfg *config.QueueConfig) *TestServer {
 		client.UnbondingStakingQueueName,
 		client.WithdrawStakingQueueName,
 		client.ExpiredStakingQueueName,
-		// purge the delay queue as well
+		// purge delay queues too
 		client.ActiveStakingQueueName + "_delay",
-		client.UnbondingStakingQueueName + "_`delay",
-		client.WithdrawStakingQueueName + "_`delay",
-		client.ExpiredStakingQueueName + "_`delay",
+		client.UnbondingStakingQueueName + "_delay",
+		client.WithdrawStakingQueueName + "_delay",
+		client.ExpiredStakingQueueName + "_delay",
 	})
 	require.NoError(t, err)
 

--- a/tests/setup.go
+++ b/tests/setup.go
@@ -15,14 +15,33 @@ import (
 	"github.com/babylonchain/staking-queue-client/queuemngr"
 )
 
-func setupTestQueueConsumer(t *testing.T, cfg *config.QueueConfig) *queuemngr.QueueManager {
+type TestServer struct {
+	QueueManager *queuemngr.QueueManager
+	Conn         *amqp091.Connection
+}
+
+func (ts *TestServer) Stop(t *testing.T) {
+	err := ts.QueueManager.Stop()
+	require.NoError(t, err)
+	err = ts.Conn.Close()
+	require.NoError(t, err)
+
+}
+
+func setupTestQueueConsumer(t *testing.T, cfg *config.QueueConfig) *TestServer {
 	amqpURI := fmt.Sprintf("amqp://%s:%s@%s", cfg.QueueUser, cfg.QueuePassword, cfg.Url)
 	conn, err := amqp091.Dial(amqpURI)
 	require.NoError(t, err)
-	defer conn.Close()
 	err = purgeQueues(conn, []string{
 		client.ActiveStakingQueueName,
-		// TODO currently other queues not exist
+		client.UnbondingStakingQueueName,
+		client.WithdrawStakingQueueName,
+		client.ExpiredStakingQueueName,
+		// purge the delay queue as well
+		client.ActiveStakingQueueName + "_delay",
+		client.UnbondingStakingQueueName + "_`delay",
+		client.WithdrawStakingQueueName + "_`delay",
+		client.ExpiredStakingQueueName + "_`delay",
 	})
 	require.NoError(t, err)
 
@@ -30,7 +49,10 @@ func setupTestQueueConsumer(t *testing.T, cfg *config.QueueConfig) *queuemngr.Qu
 	queues, err := queuemngr.NewQueueManager(cfg, zap.NewNop())
 	require.NoError(t, err)
 
-	return queues
+	return &TestServer{
+		QueueManager: queues,
+		Conn:         conn,
+	}
 }
 
 // purgeQueues purges all messages from the given list of queues.
@@ -44,9 +66,8 @@ func purgeQueues(conn *amqp091.Connection, queues []string) error {
 	for _, queue := range queues {
 		_, err := ch.QueuePurge(queue, false)
 		if err != nil {
-			if strings.Contains(err.Error(), "no queue") {
-				fmt.Printf("Queue '%s' not found, ignoring...\n", queue)
-				continue // Ignore this error and proceed with the next queue
+			if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "channel/connection is not open") {
+				continue
 			}
 			return fmt.Errorf("failed to purge queue in test %s: %w", queue, err)
 		}
@@ -119,4 +140,20 @@ func buildNExpiryEvents(numOfEvent int) []*client.ExpiredStakingEvent {
 	}
 
 	return expiryEvents
+}
+
+// inspectQueueMessageCount inspects the number of messages in the given queue.
+func inspectQueueMessageCount(t *testing.T, conn *amqp091.Connection, queueName string) (int, error) {
+	ch, err := conn.Channel()
+	if err != nil {
+		t.Fatalf("failed to open a channel in test: %v", err)
+	}
+	q, err := ch.QueueInspect(queueName)
+	if err != nil {
+		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "channel/connection is not open") {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("failed to inspect queue in test %s: %w", queueName, err)
+	}
+	return q.Messages, nil
 }

--- a/tests/setup.go
+++ b/tests/setup.go
@@ -148,7 +148,8 @@ func inspectQueueMessageCount(t *testing.T, conn *amqp091.Connection, queueName 
 	if err != nil {
 		t.Fatalf("failed to open a channel in test: %v", err)
 	}
-	q, err := ch.QueueInspect(queueName)
+
+	q, err := ch.QueueDeclarePassive(queueName, false, false, false, false, nil)
 	if err != nil {
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "channel/connection is not open") {
 			return 0, nil


### PR DESCRIPTION
This change will have impact on the infra level.
In order for it to work, we will had to delete all existing queues on mainet.  fyi @liam-icheng-lai @filippos47 

This completes the concern i had on retry failed messages (e.g out of order messages) https://github.com/babylonchain/staking-api-service/issues/38

Tested locally on the staking-api-service, all test passed just by bumping the client lib. https://github.com/babylonchain/staking-api-service/pull/64/files