### PR TITLE
add ping timeout

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -29,7 +29,7 @@ type QueueClient interface {
 	Stop() error
 	GetQueueName() string
 	ReQueueMessage(ctx context.Context, message QueueMessage) error
-	Ping() error
+	Ping(ctx context.Context) error
 }
 
 func NewQueueClient(config *config.QueueConfig, queueName string) (QueueClient, error) {

--- a/client/rabbitmq_client.go
+++ b/client/rabbitmq_client.go
@@ -113,15 +113,20 @@ func NewRabbitMqClient(config *config.QueueConfig, queueName string) (*RabbitMqC
 }
 
 // Ping checks the health of the RabbitMQ infrastructure.
-func (c *RabbitMqClient) Ping() error {
-	// Check if the RabbitMQ connection is closed
-	if c.connection.IsClosed() {
-		return fmt.Errorf("rabbitMQ connection is closed")
-	}
+func (c *RabbitMqClient) Ping(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+		// Check if the RabbitMQ connection is closed
+		if c.connection.IsClosed() {
+			return fmt.Errorf("rabbitMQ connection is closed")
+		}
 
-	// Check if the RabbitMQ channel is closed
-	if c.channel.IsClosed() {
-		return fmt.Errorf("rabbitMQ channel is closed")
+		// Check if the RabbitMQ channel is closed
+		if c.channel.IsClosed() {
+			return fmt.Errorf("rabbitMQ channel is closed")
+		}
 	}
 
 	return nil

--- a/queuemngr/queue_manager.go
+++ b/queuemngr/queue_manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"go.uber.org/zap"
 
@@ -203,20 +204,27 @@ func (qc *QueueManager) Stop() error {
 
 // Ping checks the health of the RabbitMQ infrastructure.
 func (qc *QueueManager) Ping() error {
-	queues := map[string]client.QueueClient{
-		client.ActiveStakingQueueName:   qc.StakingQueue,
-		client.UnbondingStakingQueueName: qc.UnbondingQueue,
-		client.WithdrawStakingQueueName:  qc.WithdrawQueue,
-		client.ExpiredStakingQueueName:    qc.ExpiryQueue,
-		client.StakingStatsQueueName:     qc.StatsQueue,
-		client.BtcInfoQueueName:   qc.BtcInfoQueue,
+	timeout := 5 * time.Second
+
+	queues := []client.QueueClient{
+		qc.StakingQueue,
+		qc.UnbondingQueue,
+		qc.WithdrawQueue,
+		qc.ExpiryQueue,
+		qc.StatsQueue,
+		qc.BtcInfoQueue,
 	}
 
-	for name, queue := range queues {
-		if err := queue.Ping(); err != nil {
-			return fmt.Errorf("ping failed for %s: %w", name, err)
+	for _, queue := range queues {
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		defer cancel()
+
+		err := queue.Ping(ctx)
+		if err != nil {
+			qc.logger.Error("ping failed", zap.String("queue", queue.GetQueueName()), zap.Error(err))
+			return err
 		}
+		qc.logger.Info("ping successful", zap.String("queue", queue.GetQueueName()))
 	}
-
 	return nil
 }

--- a/queuemngr/queue_manager.go
+++ b/queuemngr/queue_manager.go
@@ -12,6 +12,8 @@ import (
 	"github.com/babylonchain/staking-queue-client/config"
 )
 
+const timeout = 5 * time.Second
+
 type QueueManager struct {
 	StakingQueue   client.QueueClient
 	UnbondingQueue client.QueueClient
@@ -204,8 +206,6 @@ func (qc *QueueManager) Stop() error {
 
 // Ping checks the health of the RabbitMQ infrastructure.
 func (qc *QueueManager) Ping() error {
-	timeout := 5 * time.Second
-
 	queues := []client.QueueClient{
 		qc.StakingQueue,
 		qc.UnbondingQueue,


### PR DESCRIPTION
adds a ping timeout feature to the staking-queue-client repository. The purpose of this change is to introduce a mechanism to handle potential delays or issues with the RabbitMQ infrastructure by setting a timeout for the ping operation, include ctx param in the Ping() function, allowing for the specification of a timeout.

